### PR TITLE
Use border-box by default in _base.scss

### DIFF
--- a/stylesheets/scss/_base.scss
+++ b/stylesheets/scss/_base.scss
@@ -1,3 +1,13 @@
+html {
+	@include border-box-sizing;
+}
+
+*,
+*:after,
+*:before {
+	@include box-sizing(inherit);
+}
+
 body {
 	font-family: $font-base;
 	color: $color-base;


### PR DESCRIPTION
I think we're all doing this, but it isn't in the boilerplate yet.
