### PR TITLE
box-sizing fix

### DIFF
--- a/stylesheets/scss/_base.scss
+++ b/stylesheets/scss/_base.scss
@@ -1,5 +1,5 @@
 html {
-	@include border-box-sizing;
+	@include box-sizing(border-box);
 }
 
 *,


### PR DESCRIPTION
As Jamie mentioned, there's an error when you try to compile a freshly pulled sassyplate `undefined mixin border-box-sizing`. I just had the same error.
Looks like border-box-sizing is not a part of compass or was deprecated.
I guess it needs to be replaced with `@include box-sizing(border-box);`.
