### PR TITLE
Removed partials directory

### DIFF
--- a/stylesheets/scss/screen.scss
+++ b/stylesheets/scss/screen.scss
@@ -36,8 +36,5 @@
 // NOTE: This file only exists in the drupal branch.
 // @import "modules/drupal-reset";
 
-// Partials
-// @import "partials/partial-name";
-
 // Print, inlined to avoid the additional HTTP request: h5bp.com/r
 @import "print";


### PR DESCRIPTION
Basically _everybody_ has asked for clarification on the difference between partials and modules at some point. I've always struggled to answer this because although this _did_ make sense to me at one point, it no longer does. We've gotten so good at modularity that I no longer believe this is useful in any way, and provides more confusion than clarity.
